### PR TITLE
feat: Accept Buffer as an additional payload type

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,9 @@ PubSubService pubSubService = PubSubService.createProxy(vertx, "any-address");
 
 Optionally, you can skip the use of the service proxy and simply use the service as-is. You implement a Verticle and call `PubSubService.create(Vertx)` and you then have the service instance.
 
-The library contains a DTO entity (`PubSubMessage`) that is used to publish a message via the service. This DTO contains a topic id, and a payload. The PubSubService is able to maintain multiple PubSub publishers for different topic ids and will set up new publishers for any new, unknown, topic ids. Because of this, it is recommended to deploy this service once in your application.
+The library contains a DTO entity (`PubSubMessage`) that is used to publish a message via the service. This DTO contains a topic id, and a payload. While you can set both `JsonObject` and `byte[]` for the payload type, the `JsonObject` takes precedence and `byte[]` will only be used if no `JsonObject` is set.
+
+The PubSubService is able to maintain multiple PubSub publishers for different topic ids and will set up new publishers for any new, unknown, topic ids. Because of this, it is recommended to deploy this service once in your application.
 
 == Documentation
 

--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ PubSubService pubSubService = PubSubService.createProxy(vertx, "any-address");
 
 Optionally, you can skip the use of the service proxy and simply use the service as-is. You implement a Verticle and call `PubSubService.create(Vertx)` and you then have the service instance.
 
-The library contains a DTO entity (`PubSubMessage`) that is used to publish a message via the service. This DTO contains a topic id, and a payload. While you can set both `JsonObject` and `byte[]` for the payload type, the `JsonObject` takes precedence and `byte[]` will only be used if no `JsonObject` is set.
+The library contains a DTO entity (`PubSubMessage`) that is used to publish a message via the service. This DTO contains a topic id, and a payload. While you can set both `JsonObject` and `Buffer` for the payload type, the `JsonObject` takes precedence and `Buffer` will only be used if no `JsonObject` is set.
 
 The PubSubService is able to maintain multiple PubSub publishers for different topic ids and will set up new publishers for any new, unknown, topic ids. Because of this, it is recommended to deploy this service once in your application.
 

--- a/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
+++ b/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
@@ -7,7 +7,7 @@ import io.vertx.core.json.JsonObject;
 import java.util.Map;
 
 /**
- * Value object to send a PubSub message via {@link PubSubService}.
+ * Value object to send a PubSub message via {@link PubSubService}
  *
  * @author thced
  */

--- a/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
+++ b/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
@@ -2,11 +2,14 @@ package com.extendaretail.vertx.gcp.pubsub.v1;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.annotations.Fluent;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import java.util.Map;
 
 /**
- * Value object to send a PubSub message via {@link PubSubService}
+ * Value object to send a PubSub message via {@link PubSubService}. While you can set both a Vertx
+ * {@link JsonObject} and {@link Buffer} for the payload type, the {@link Buffer} takes precedence
+ * and byte[] will only be used if no {@link Buffer} is set.
  *
  * @author thced
  */
@@ -15,12 +18,14 @@ public class PubSubMessage {
 
   private String topic;
   private JsonObject message;
+  private Buffer bufferMessage;
   private Map<String, String> attributes;
 
   public PubSubMessage() {
     this.topic = null;
     this.message = null;
     this.attributes = null;
+    this.bufferMessage = null;
   }
 
   public PubSubMessage(JsonObject json) {
@@ -60,6 +65,16 @@ public class PubSubMessage {
   @Fluent
   public PubSubMessage setAttributes(Map<String, String> attributes) {
     this.attributes = attributes;
+    return this;
+  }
+
+  public Buffer getBufferMessage() {
+    return bufferMessage;
+  }
+
+  @Fluent
+  public PubSubMessage setBufferMessage(Buffer bufferMessage) {
+    this.bufferMessage = bufferMessage;
     return this;
   }
 }

--- a/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
+++ b/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubMessage.java
@@ -7,9 +7,7 @@ import io.vertx.core.json.JsonObject;
 import java.util.Map;
 
 /**
- * Value object to send a PubSub message via {@link PubSubService}. While you can set both a Vertx
- * {@link JsonObject} and {@link Buffer} for the payload type, the {@link Buffer} takes precedence
- * and byte[] will only be used if no {@link Buffer} is set.
+ * Value object to send a PubSub message via {@link PubSubService}.
  *
  * @author thced
  */

--- a/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubService.java
+++ b/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubService.java
@@ -3,6 +3,8 @@ package com.extendaretail.vertx.gcp.pubsub.v1;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceException;
 
 /**
@@ -46,7 +48,9 @@ public interface PubSubService {
   }
 
   /**
-   * Publish a message on PubSub
+   * Publish a message on PubSub. While you can set both a Vertx {@link JsonObject} and {@link
+   * Buffer} for the payload type, the {@link JsonObject} takes precedence. {@link Buffer} will only
+   * be used for the payload if not {@link JsonObject} is set.
    *
    * @param message The message to send
    * @return Future containing the result, or a failure

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubContainerExtension.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubContainerExtension.java
@@ -19,7 +19,13 @@ import com.google.pubsub.v1.TopicName;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import java.io.IOException;
-import org.junit.jupiter.api.extension.*;
+import java.util.UUID;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
 import org.testcontainers.containers.PubSubEmulatorContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -72,7 +78,7 @@ public class PubSubContainerExtension
     Publisher publisher = null;
     SubscriberStub subscriber = null;
 
-    String topicId = "test1";
+    String topicId = generateRandomTopicId();
     String subscriptionId = "test";
 
     try {
@@ -98,6 +104,10 @@ public class PubSubContainerExtension
     }
 
     return new Tooling(publisher, topicId, subscriber, subscriptionId, PROJECT_ID, hostPort);
+  }
+
+  private String generateRandomTopicId() {
+    return "testTopic" + UUID.randomUUID().toString().split("-")[0];
   }
 
   private void createTopic(

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubContainerExtension.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubContainerExtension.java
@@ -79,7 +79,7 @@ public class PubSubContainerExtension
     SubscriberStub subscriber = null;
 
     String topicId = generateRandomTopicId();
-    String subscriptionId = "test";
+    String subscriptionId = generateRandomSubscriptionId();
 
     try {
       createTopic(topicId, channelProvider, credentialsProvider);
@@ -106,8 +106,16 @@ public class PubSubContainerExtension
     return new Tooling(publisher, topicId, subscriber, subscriptionId, PROJECT_ID, hostPort);
   }
 
+  private String generateRandomSubscriptionId() {
+    return "testSubscription" + randomAlphanumericString();
+  }
+
   private String generateRandomTopicId() {
-    return "testTopic" + UUID.randomUUID().toString().split("-")[0];
+    return "testTopic" + randomAlphanumericString();
+  }
+
+  private String randomAlphanumericString() {
+    return UUID.randomUUID().toString().split("-")[0];
   }
 
   private void createTopic(

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubServiceImplTest.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubServiceImplTest.java
@@ -49,10 +49,17 @@ class PubSubServiceImplTest {
             .setMessage(new JsonObject(jsonPayload))
             .setBufferMessage(bufferMessageToBeIgnored);
 
-    service.publish(message).onComplete(testContext.succeedingThenComplete());
+    Checkpoint publish = testContext.checkpoint();
+    Checkpoint assertLastMessage = testContext.checkpoint();
 
-    assertThat(tooling.receiveLastMessage().getMessage().getData().toStringUtf8())
-        .isEqualTo(jsonPayload);
+    service.publish(message).onComplete(ignore -> publish.flag());
+
+    testContext.verify(
+        () -> {
+          assertThat(tooling.receiveLastMessage().getMessage().getData().toStringUtf8())
+              .isEqualTo(jsonPayload);
+          assertLastMessage.flag();
+        });
   }
 
   @Test
@@ -69,10 +76,17 @@ class PubSubServiceImplTest {
             .setTopic(tooling.getTopicId())
             .setBufferMessage(Buffer.buffer(bufferMessagePayload.getBytes(StandardCharsets.UTF_8)));
 
-    service.publish(message).onComplete(testContext.succeedingThenComplete());
+    Checkpoint publish = testContext.checkpoint();
+    Checkpoint assertLastMessage = testContext.checkpoint();
 
-    assertThat(tooling.receiveLastMessage().getMessage().getData().toStringUtf8())
-        .isEqualTo(bufferMessagePayload);
+    service.publish(message).onComplete(ignore -> publish.flag());
+
+    testContext.verify(
+        () -> {
+          assertThat(tooling.receiveLastMessage().getMessage().getData().toStringUtf8())
+              .isEqualTo(bufferMessagePayload);
+          assertLastMessage.flag();
+        });
   }
 
   @Test

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubServiceImplTest.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/PubSubServiceImplTest.java
@@ -1,14 +1,19 @@
 package com.extendaretail.vertx.gcp.pubsub.v1;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 
 import com.google.api.core.ApiFutures;
 import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.ReceivedMessage;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.*;
 import io.vertx.junit5.Timeout;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
 import org.mockito.Mock;
@@ -27,6 +32,47 @@ class PubSubServiceImplTest {
         new PubSubMessage().setTopic(tooling.getTopicId()).setMessage(new JsonObject());
 
     service.publish(message).onComplete(testContext.succeedingThenComplete());
+  }
+
+  @Test
+  @Timeout(5000)
+  void testJsonObjectDataShouldTakePrecedenceOverBufferMessage(
+      Vertx vertx, VertxTestContext testContext, Tooling tooling) { // NOSONAR
+    PubSubServiceImpl service = new PubSubServiceImpl(vertx);
+    service.getPublishers().put(tooling.getTopicId(), tooling.getPublisher());
+
+    PubSubMessage message =
+        new PubSubMessage()
+            .setTopic(tooling.getTopicId())
+            .setMessage(new JsonObject("{\"message\":\"Hello World\"}"))
+            .setBufferMessage(Buffer.buffer("ByteArrayMessage".getBytes(StandardCharsets.UTF_8)));
+
+    service.publish(message).onComplete(testContext.succeedingThenComplete());
+
+    List<ReceivedMessage> receivedMessage = tooling.receiveMessages(1);
+
+    assertThat(receivedMessage.get(0).getMessage().getData().toStringUtf8())
+        .isEqualTo("{\"message\":\"Hello World\"}");
+  }
+
+  @Test
+  @Timeout(5000)
+  void testBufferMessageSending(
+      Vertx vertx, VertxTestContext testContext, Tooling tooling) { // NOSONAR
+    PubSubServiceImpl service = new PubSubServiceImpl(vertx);
+    service.getPublishers().put(tooling.getTopicId(), tooling.getPublisher());
+
+    PubSubMessage message =
+        new PubSubMessage()
+            .setTopic(tooling.getTopicId())
+            .setBufferMessage(Buffer.buffer("ByteArrayMessage".getBytes(StandardCharsets.UTF_8)));
+
+    service.publish(message).onComplete(testContext.succeedingThenComplete());
+
+    List<ReceivedMessage> receivedMessage = tooling.receiveMessages(1);
+
+    assertThat(receivedMessage.get(0).getMessage().getData().toStringUtf8())
+        .isEqualTo("ByteArrayMessage");
   }
 
   @Test

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/Tooling.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/Tooling.java
@@ -6,7 +6,6 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.ReceivedMessage;
-import java.util.List;
 
 /**
  * Add as test method parameter to get references to the publisher and the subscriber, within tests.
@@ -61,13 +60,13 @@ public class Tooling {
     return hostPort;
   }
 
-  public List<ReceivedMessage> receiveMessages(int amountOfMessagesToPull) {
+  public ReceivedMessage receiveLastMessage() {
     PullRequest pullRequest =
         PullRequest.newBuilder()
-            .setMaxMessages(amountOfMessagesToPull)
+            .setMaxMessages(1)
             .setSubscription(ProjectSubscriptionName.format(projectId, subscriptionId))
             .build();
     PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
-    return pullResponse.getReceivedMessagesList();
+    return pullResponse.getReceivedMessages(0);
   }
 }

--- a/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/Tooling.java
+++ b/src/test/java/com/extendaretail/vertx/gcp/pubsub/v1/Tooling.java
@@ -2,6 +2,11 @@ package com.extendaretail.vertx.gcp.pubsub.v1;
 
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.util.List;
 
 /**
  * Add as test method parameter to get references to the publisher and the subscriber, within tests.
@@ -54,5 +59,15 @@ public class Tooling {
 
   public String getHostPort() {
     return hostPort;
+  }
+
+  public List<ReceivedMessage> receiveMessages(int amountOfMessagesToPull) {
+    PullRequest pullRequest =
+        PullRequest.newBuilder()
+            .setMaxMessages(amountOfMessagesToPull)
+            .setSubscription(ProjectSubscriptionName.format(projectId, subscriptionId))
+            .build();
+    PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
+    return pullResponse.getReceivedMessagesList();
   }
 }


### PR DESCRIPTION
To re-use the `PubSubService` for places where no `JsonObject` needs to be send to Pub/Sub, we enrich the public API to let users directly set a `Buffer` that will be used as the payload if no `JsonObject` is set.