### PR TITLE
fix: Keep a cache of Emulator channel providers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 default_stages: [commit]
 
 repos:
-  - repo: git://github.com/extenda/pre-commit-hooks
-    rev: v0.4
+  - repo: https://github.com/extenda/pre-commit-hooks
+    rev: v0.8.0
     hooks:
       - id: google-java-formatter
       - id: commitlint

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,15 @@
 
     <vertx.version>4.3.2</vertx.version>
 
-    <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-    <junit-jupiter.version>5.8.1</junit-jupiter.version>
-    <mockito.version>4.1.0</mockito.version>
-    <testcontainers.version>1.17.1</testcontainers.version>
-    <assertj.version>3.22.0</assertj.version>
+    <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
+    <junit-jupiter.version>5.9.2</junit-jupiter.version>
+    <mockito.version>5.3.0</mockito.version>
+    <testcontainers.version>1.18.0</testcontainers.version>
+    <assertj.version>3.24.2</assertj.version>
     <!-- Sonar settings -->
     <sonar.junit.reportPaths>${project.build.directory}/surefire-reports</sonar.junit.reportPaths>
     <sonar.jacoco.reportPaths>${project.build.directory}/jacoco.exec, ${user.dir}/target/jacoco-it.exec</sonar.jacoco.reportPaths>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>24.1.0</version>
+        <version>26.12.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
     <junit-jupiter.version>5.9.2</junit-jupiter.version>
-    <mockito.version>5.3.0</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <testcontainers.version>1.18.0</testcontainers.version>
     <assertj.version>3.24.2</assertj.version>
     <!-- Sonar settings -->

--- a/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/EmulatorRedirect.java
+++ b/src/main/java/com/extendaretail/vertx/gcp/pubsub/v1/EmulatorRedirect.java
@@ -8,6 +8,8 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher.Builder;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Based on <a
@@ -21,16 +23,24 @@ public class EmulatorRedirect {
 
   private EmulatorRedirect() {}
 
+  private static final Map<String, TransportChannelProvider> channelProviders =
+      new ConcurrentHashMap<>();
+
   public static void redirect(Builder builder) {
     String hostPort =
         System.getProperty("PUBSUB_EMULATOR_HOST", System.getenv("PUBSUB_EMULATOR_HOST"));
-    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostPort).usePlaintext().build();
 
     TransportChannelProvider channelProvider =
-        FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+        channelProviders.computeIfAbsent(hostPort, EmulatorRedirect::createChannelProvider);
+
     CredentialsProvider credentialsProvider = NoCredentialsProvider.create();
 
     // Set the channel and credentials provider when creating a `Publisher`.
     builder.setChannelProvider(channelProvider).setCredentialsProvider(credentialsProvider);
+  }
+
+  private static TransportChannelProvider createChannelProvider(String hostPort) {
+    ManagedChannel channel = ManagedChannelBuilder.forTarget(hostPort).usePlaintext().build();
+    return FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
   }
 }


### PR DESCRIPTION
When creating multiple calls for the emulator, a new channel was created each call. This will re-use the channel and have it properly shut down.